### PR TITLE
Fix E118 on atags#generateOnExit when generating tags

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,4 +4,4 @@
 Gianluca Arbezzano <gianarb92@gmail.com>
 Giulio Collura <giulio.collura@gmail.com>
 Lorenzo Fontana <fontanalorenzo@me.com>
-
+Yann Hamdaoui <yann.hamdaoui@centraliens.net>

--- a/autoload/atags.vim
+++ b/autoload/atags.vim
@@ -8,19 +8,19 @@ let g:autoloaded_atags = 1
 
 let g:atags_had_errors=0
 
-function! atags#onGenerateErr(id, data)
+function! atags#onGenerateErr(id, data, event)
   let g:atags_had_errors=1
   let msg = "❗ An error occurred generating ctags: " . join(a:data)
   echom msg
 endfunction
 
-function! atags#onGenerateOut()
+function! atags#onGenerateOut(id, data, event)
   if g:atags_had_errors==0 && g:atags_quiet==0
     echom "🎉 tags generated  🎉"
   endif
 endfunction
 
-function! atags#onGenerateExit()
+function! atags#onGenerateExit(id, data, event)
 
 endfunction
 


### PR DESCRIPTION
Hello,

Since December 2016, I've had some problem with atags, mainly an error message E118 stating that the call to atags#generateOnExit have too many arguments each time atags tried to generate tags (which can happen a lot if, like me, one uses "autocmd BufWritePost * call atags#generate()"

This comes from a change in the Neovim requirement for jobcontrol handlers that is specified here : https://github.com/neovim/neovim/issues/5763#issuecomment-266722407. They now need to have 3 arguments, event if they don't use them. This PR attempts to fix this problem by adding the missing arguments.

I tested it in my daily usage and it seems fine (no more error messages and tags are still correctly generated).